### PR TITLE
Keycloak: Add user roles to default realm config

### DIFF
--- a/keycloak-realm/GITS-realm.json
+++ b/keycloak-realm/GITS-realm.json
@@ -46,9 +46,27 @@
   "roles": {
     "realm": [
       {
+        "id": "1a6ea30e-7795-4372-a783-908f195b6860",
+        "name": "super-user",
+        "description": "",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "1d75c2e1-55cb-471a-a89c-d81ea87e1646",
+        "attributes": {}
+      },
+      {
         "id": "352eeedd-584a-4364-b0c6-1086b2014ba2",
         "name": "offline_access",
         "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "1d75c2e1-55cb-471a-a89c-d81ea87e1646",
+        "attributes": {}
+      },
+      {
+        "id": "7939ace1-eca6-4230-b4b7-aa1e2ba2478c",
+        "name": "course-creator",
+        "description": "",
         "composite": false,
         "clientRole": false,
         "containerId": "1d75c2e1-55cb-471a-a89c-d81ea87e1646",
@@ -60,9 +78,15 @@
         "description": "${role_default-roles}",
         "composite": true,
         "composites": {
-          "realm": ["offline_access", "uma_authorization"],
+          "realm": [
+            "offline_access",
+            "uma_authorization"
+          ],
           "client": {
-            "account": ["view-profile", "manage-account"]
+            "account": [
+              "view-profile",
+              "manage-account"
+            ]
           }
         },
         "clientRole": false,
@@ -148,7 +172,9 @@
           "composite": true,
           "composites": {
             "client": {
-              "realm-management": ["query-clients"]
+              "realm-management": [
+                "query-clients"
+              ]
             }
           },
           "clientRole": true,
@@ -225,7 +251,10 @@
           "composite": true,
           "composites": {
             "client": {
-              "realm-management": ["query-groups", "query-users"]
+              "realm-management": [
+                "query-groups",
+                "query-users"
+              ]
             }
           },
           "clientRole": true,
@@ -289,7 +318,6 @@
       ],
       "security-admin-console": [],
       "admin-cli": [],
-      "frontend": [],
       "account-console": [],
       "broker": [
         {
@@ -328,7 +356,9 @@
           "composite": true,
           "composites": {
             "client": {
-              "account": ["view-consent"]
+              "account": [
+                "view-consent"
+              ]
             }
           },
           "clientRole": true,
@@ -351,7 +381,9 @@
           "composite": true,
           "composites": {
             "client": {
-              "account": ["manage-account-links"]
+              "account": [
+                "manage-account-links"
+              ]
             }
           },
           "clientRole": true,
@@ -385,7 +417,8 @@
           "containerId": "a85f730e-c8ea-4a58-be2e-856c99c1fb52",
           "attributes": {}
         }
-      ]
+      ],
+      "frontend": []
     }
   },
   "groups": [],
@@ -397,7 +430,9 @@
     "clientRole": false,
     "containerId": "1d75c2e1-55cb-471a-a89c-d81ea87e1646"
   },
-  "requiredCredentials": ["password"],
+  "requiredCredentials": [
+    "password"
+  ],
   "otpPolicyType": "totp",
   "otpPolicyAlgorithm": "HmacSHA1",
   "otpPolicyInitialCounter": 0,
@@ -406,12 +441,14 @@
   "otpPolicyPeriod": 30,
   "otpPolicyCodeReusable": false,
   "otpSupportedApplications": [
-    "totpAppGoogleName",
     "totpAppFreeOTPName",
-    "totpAppMicrosoftAuthenticatorName"
+    "totpAppMicrosoftAuthenticatorName",
+    "totpAppGoogleName"
   ],
   "webAuthnPolicyRpEntityName": "keycloak",
-  "webAuthnPolicySignatureAlgorithms": ["ES256"],
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256"
+  ],
   "webAuthnPolicyRpId": "",
   "webAuthnPolicyAttestationConveyancePreference": "not specified",
   "webAuthnPolicyAuthenticatorAttachment": "not specified",
@@ -421,7 +458,9 @@
   "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
   "webAuthnPolicyAcceptableAaguids": [],
   "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
-  "webAuthnPolicyPasswordlessSignatureAlgorithms": ["ES256"],
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256"
+  ],
   "webAuthnPolicyPasswordlessRpId": "",
   "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
   "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
@@ -433,14 +472,19 @@
   "scopeMappings": [
     {
       "clientScope": "offline_access",
-      "roles": ["offline_access"]
+      "roles": [
+        "offline_access"
+      ]
     }
   ],
   "clientScopeMappings": {
     "account": [
       {
         "client": "account-console",
-        "roles": ["manage-account", "view-groups"]
+        "roles": [
+          "manage-account",
+          "view-groups"
+        ]
       }
     ]
   },
@@ -455,7 +499,9 @@
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
-      "redirectUris": ["/realms/GITS/account/*"],
+      "redirectUris": [
+        "/realms/GITS/account/*"
+      ],
       "webOrigins": [],
       "notBefore": 0,
       "bearerOnly": false,
@@ -497,7 +543,9 @@
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
-      "redirectUris": ["/realms/GITS/account/*"],
+      "redirectUris": [
+        "/realms/GITS/account/*"
+      ],
       "webOrigins": [],
       "notBefore": 0,
       "bearerOnly": false,
@@ -632,8 +680,12 @@
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
-      "redirectUris": ["http://localhost:3005"],
-      "webOrigins": ["http://localhost:3005"],
+      "redirectUris": [
+        "http://localhost:3005"
+      ],
+      "webOrigins": [
+        "http://localhost:3005"
+      ],
       "notBefore": 0,
       "bearerOnly": false,
       "consentRequired": false,
@@ -646,10 +698,10 @@
       "protocol": "openid-connect",
       "attributes": {
         "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
         "post.logout.redirect.uris": "http://localhost:3005",
         "oauth2.device.authorization.grant.enabled": "false",
         "display.on.consent.screen": "false",
-        "backchannel.logout.session.required": "true",
         "backchannel.logout.revoke.offline.tokens": "false"
       },
       "authenticationFlowBindingOverrides": {},
@@ -719,8 +771,12 @@
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
-      "redirectUris": ["/admin/GITS/console/*"],
-      "webOrigins": ["+"],
+      "redirectUris": [
+        "/admin/GITS/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
       "notBefore": 0,
       "bearerOnly": false,
       "consentRequired": false,
@@ -746,12 +802,12 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "locale",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "locale",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "String"
           }
         }
       ],
@@ -778,8 +834,8 @@
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "true",
-        "consent.screen.text": "${phoneScopeConsentText}",
-        "display.on.consent.screen": "true"
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${phoneScopeConsentText}"
       },
       "protocolMappers": [
         {
@@ -789,12 +845,12 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "phoneNumberVerified",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "phone_number_verified",
-            "jsonType.label": "boolean",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "boolean"
           }
         },
         {
@@ -804,12 +860,12 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "phoneNumber",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "phone_number",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "String"
           }
         }
       ]
@@ -847,12 +903,12 @@
           "protocolMapper": "oidc-usermodel-property-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "username",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "upn",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "String"
           }
         }
       ]
@@ -874,8 +930,8 @@
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "true",
-        "consent.screen.text": "${emailScopeConsentText}",
-        "display.on.consent.screen": "true"
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${emailScopeConsentText}"
       },
       "protocolMappers": [
         {
@@ -885,12 +941,12 @@
           "protocolMapper": "oidc-usermodel-property-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "email",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "email",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "String"
           }
         },
         {
@@ -900,12 +956,12 @@
           "protocolMapper": "oidc-usermodel-property-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "emailVerified",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "email_verified",
-            "jsonType.label": "boolean",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "boolean"
           }
         }
       ]
@@ -917,8 +973,8 @@
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "false",
-        "consent.screen.text": "",
-        "display.on.consent.screen": "false"
+        "display.on.consent.screen": "false",
+        "consent.screen.text": ""
       },
       "protocolMappers": [
         {
@@ -962,8 +1018,8 @@
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "false",
-        "consent.screen.text": "${rolesScopeConsentText}",
-        "display.on.consent.screen": "true"
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${rolesScopeConsentText}"
       },
       "protocolMappers": [
         {
@@ -1035,8 +1091,8 @@
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "true",
-        "consent.screen.text": "${profileScopeConsentText}",
-        "display.on.consent.screen": "true"
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${profileScopeConsentText}"
       },
       "protocolMappers": [
         {
@@ -1046,12 +1102,12 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "website",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "website",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "String"
           }
         },
         {
@@ -1061,12 +1117,12 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "birthdate",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "birthdate",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "String"
           }
         },
         {
@@ -1076,12 +1132,12 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "zoneinfo",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "zoneinfo",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "String"
           }
         },
         {
@@ -1091,12 +1147,12 @@
           "protocolMapper": "oidc-usermodel-property-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "lastName",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "family_name",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "String"
           }
         },
         {
@@ -1106,12 +1162,12 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "middleName",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "middle_name",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "String"
           }
         },
         {
@@ -1121,12 +1177,12 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "profile",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "profile",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "String"
           }
         },
         {
@@ -1136,12 +1192,12 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "gender",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "gender",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "String"
           }
         },
         {
@@ -1151,12 +1207,12 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "nickname",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "nickname",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "String"
           }
         },
         {
@@ -1166,12 +1222,12 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "locale",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "locale",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "String"
           }
         },
         {
@@ -1193,12 +1249,12 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "picture",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "picture",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "String"
           }
         },
         {
@@ -1208,12 +1264,12 @@
           "protocolMapper": "oidc-usermodel-property-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "username",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "preferred_username",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "String"
           }
         },
         {
@@ -1223,12 +1279,12 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "updatedAt",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "updated_at",
-            "jsonType.label": "long",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "long"
           }
         },
         {
@@ -1238,12 +1294,12 @@
           "protocolMapper": "oidc-usermodel-property-mapper",
           "consentRequired": false,
           "config": {
+            "userinfo.token.claim": "true",
             "user.attribute": "firstName",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "given_name",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
+            "jsonType.label": "String"
           }
         }
       ]
@@ -1255,8 +1311,8 @@
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "true",
-        "consent.screen.text": "${addressScopeConsentText}",
-        "display.on.consent.screen": "true"
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${addressScopeConsentText}"
       },
       "protocolMappers": [
         {
@@ -1306,7 +1362,9 @@
   },
   "smtpServer": {},
   "eventsEnabled": false,
-  "eventsListeners": ["jboss-logging"],
+  "eventsListeners": [
+    "jboss-logging"
+  ],
   "enabledEventTypes": [],
   "adminEventsEnabled": false,
   "adminEventsDetailsEnabled": false,
@@ -1321,8 +1379,12 @@
         "subType": "anonymous",
         "subComponents": {},
         "config": {
-          "host-sending-registration-request-must-match": ["true"],
-          "client-uris-must-match": ["true"]
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
         }
       },
       {
@@ -1341,14 +1403,14 @@
         "subComponents": {},
         "config": {
           "allowed-protocol-mapper-types": [
-            "saml-user-attribute-mapper",
             "oidc-usermodel-attribute-mapper",
-            "oidc-address-mapper",
-            "oidc-sha256-pairwise-sub-mapper",
             "oidc-full-name-mapper",
             "saml-user-property-mapper",
             "oidc-usermodel-property-mapper",
-            "saml-role-list-mapper"
+            "saml-role-list-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-address-mapper",
+            "oidc-sha256-pairwise-sub-mapper"
           ]
         }
       },
@@ -1367,7 +1429,9 @@
         "subType": "anonymous",
         "subComponents": {},
         "config": {
-          "allow-default-scopes": ["true"]
+          "allow-default-scopes": [
+            "true"
+          ]
         }
       },
       {
@@ -1377,7 +1441,9 @@
         "subType": "anonymous",
         "subComponents": {},
         "config": {
-          "max-clients": ["200"]
+          "max-clients": [
+            "200"
+          ]
         }
       },
       {
@@ -1389,13 +1455,13 @@
         "config": {
           "allowed-protocol-mapper-types": [
             "oidc-sha256-pairwise-sub-mapper",
-            "oidc-full-name-mapper",
+            "oidc-usermodel-attribute-mapper",
             "saml-role-list-mapper",
-            "oidc-address-mapper",
-            "oidc-usermodel-property-mapper",
-            "saml-user-attribute-mapper",
             "saml-user-property-mapper",
-            "oidc-usermodel-attribute-mapper"
+            "oidc-address-mapper",
+            "oidc-full-name-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-property-mapper"
           ]
         }
       },
@@ -1406,7 +1472,9 @@
         "subType": "authenticated",
         "subComponents": {},
         "config": {
-          "allow-default-scopes": ["true"]
+          "allow-default-scopes": [
+            "true"
+          ]
         }
       }
     ],
@@ -1425,13 +1493,9 @@
         "providerId": "rsa-generated",
         "subComponents": {},
         "config": {
-          "privateKey": [
-            "MIIEowIBAAKCAQEAwvj5tH7C30y9qch6rw0LIppLhEFQphZc/9peACQ2PQA8h1K3oAg/xo/ph9S5lsYNSIhaAPK3B2RCdtja9HwDSZN7ohDJLkdwfKmYe89qJ2K7zsDgwBa0L504kTlrw4CnZuoAt5lloETG5BsyWdZHvBmcq5OnU5Dp+bt+4twzzSdrU+4iPT1BquOVEUbiCUbldFiAQL9onCJs+71fTNXykWcVGb59pMhrMSPUdMgznlpbK3RUb6LI51GrE6MVZZKKZOgGuxyrxPDNWbLbUrL1kVieGSoSqO3qQo0lpZSQ8bmbL0wg27appY3ciQVk9SsK1q71xC/OLsLG/fnUJCpBAQIDAQABAoIBAB9PpiRNLiT3uUbEpiUqGlVwg3umFJpToZRKIInzxs0VlmLiDxCxenJ8JpQUfsh+nl/9W7zmvat/d6gH6+PS7aE5gOOWQATBXsh6YP1TIjhYhBIwSfe3PbEe1diGqO6A4QFnR320sgwit3EnB/dC8Qq9bzpjsD28mkKrkHVEyUHjEE3xTlhuuZE8Oed/gEfCngXEhkMqfH2Axy9aRJCcfWbfAhTkH/jj1qBdKGego1c2n0mDPBSFzbljp5je9In+wmB/FntGlwxv1xMOV2eRGmg+PtPiZ9kVL+9hylyxkoax8TmsVQ0xBek2dSoiDTHjF6XPOgXTD89IrQiLdpCOYuUCgYEA+NUdEj9bkfYN3hfuxu83RQh6FuCK5LZ4oFmVLYB2xqPbDjRk2dX3TsiRjFx0elvq9zsfG6aVTfv0Qg4SsxjeC86tPQEpndt7DdgNQTnOVaBAAZumnBYyNQXapymfDjemtfl7A3GQzewmFC+uXLUvYbKl4EIVFwewZBLB1KOpimUCgYEAyJazIy1guPf0bQ4ea/WVjTuaf9WDC9qv0inzag5DW3KOihyzGXFPLgzjhzOo4Bb2sMSLNLFXB12H3hD9HmtxXtgo38qMbmKFdGwE5yBUb1vthr92GpZt+CAX4AQnlm9EbR8ocxBIT2nuYV3db8K1nSnsw2P0A2ejo6tEFZAhxG0CgYEA7WGZx0OsHtXmKt8YCq5BQtkwZ8y0lDZDY22ys+Le7Od6XdW79Fh8Aquytn2pHOW9hTfgmGdV/jyDq9RzIGpzwj3b5NvMEO1GOlHHa1czMVqcVSxhSHygTxcTne9F7rFGmEm1gfaAVwKW3SETrRuoZQKh3gwMxJiwPPfr8+hiIEUCgYBzr15PSmt/IhoJD1yCPRfsZVS8p0I2AwDl/6XQI7u7MP1+MAEnCk91Kp/KqQObggLyfdgfIqwjplCmxTuGYMb4wUgJkYKeYxm+xFGrjtzDgMwjq6aMvPddY/0BCMRgIXngSVkFy304t8pwwzbjrvMZWkWfhrUDhbE9wpe4q/CdnQKBgFaajp2Ujh0Rd6yQeqWk0m8IoxC43+mQ85v0ITf9YfdmdzJa95aSHvDem3SC47zh8ZG6XBLnvutyvusp4Z8wrL14HDwTM0r8O3dEuV83EeMxBc/yc+RU32tib/gp7D6yCCwPYpqsPsmUqYSP03PaxIHsaiXh2tyQCtgAtaiLTiMZ"
-          ],
-          "certificate": [
-            "MIIClzCCAX8CBgGK2yCMRjANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDARHSVRTMB4XDTIzMDkyODA5MjkxN1oXDTMzMDkyODA5MzA1N1owDzENMAsGA1UEAwwER0lUUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAML4+bR+wt9MvanIeq8NCyKaS4RBUKYWXP/aXgAkNj0APIdSt6AIP8aP6YfUuZbGDUiIWgDytwdkQnbY2vR8A0mTe6IQyS5HcHypmHvPaidiu87A4MAWtC+dOJE5a8OAp2bqALeZZaBExuQbMlnWR7wZnKuTp1OQ6fm7fuLcM80na1PuIj09QarjlRFG4glG5XRYgEC/aJwibPu9X0zV8pFnFRm+faTIazEj1HTIM55aWyt0VG+iyOdRqxOjFWWSimToBrscq8TwzVmy21Ky9ZFYnhkqEqjt6kKNJaWUkPG5my9MINu2qaWN3IkFZPUrCtau9cQvzi7Cxv351CQqQQECAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAaDm1X1AiANvwXs6lDIQG19bOCckRjYTmxqPWY0L4DZZml3fL9rsKdZo/vqm2f8giCtmIyTAPUGiyjjqj4tsyFdxDlPTt6pVo7MtHCkXnLjl4CfSvT3bp1FJjul6c8sW9HsktFGi/uzYR5u+qvE3Wm+eoXuvQXa6lsQncAOEXHNm1+jxlvPfoe+FGy0wldEEz+iUGJR5CNxxzGg2Zn22XdbkWJDTUmxjb8sFmnFyOfUBVMemm25wSxYTFhNUyaQTsgT6ZE/jbuQtBJYBStAdPYAmmovAbcPKVaJf+M1YTy8GCrModoVQUim3BBPTY3xtOtpjqjX0s5E5MW3xSqOo8/g=="
-          ],
-          "priority": ["100"]
+          "priority": [
+            "100"
+          ]
         }
       },
       {
@@ -1440,14 +1504,12 @@
         "providerId": "rsa-enc-generated",
         "subComponents": {},
         "config": {
-          "privateKey": [
-            "MIIEowIBAAKCAQEAlfM5xnSB8dg2AgDsc/0TRiIrRB2hq8w4DFn5nUOk5T41u32S5Tp7oDjaS5ktqdE7/6smT9OEkL+J8wH8Y47r+8ljOFzxapAPvDLcV7XZfrYdXOZGRbXLituP3pQ3hKJmCVNZLCb/M3pqSJb5KsHgLNfHmoyZijgqdBoKpWvoBKh6UCtgWaeIaNJLDkbduhcbc3GqHo2Hwl8nMxoqF/4tLdqQMwr9i5E1BguLU3lbpNCM4raHGCjDsecVUcO9bkBkWxz8pv3VAm3/VL02phAjkwHYJmQY7B5DYgV60qbGW3HyuRr2Q2xc5IWFwSY604jIxw17tdIjdpUT36mRja7XdwIDAQABAoIBADVhdW9fOYVBbZSQBJ0T+mEMt+9TRyMUG93VyAVCt/h+CX3Z6cnd5HW414lzGezq1huhr41aZMZs0Wynh9RfZEXpvv8pIy5G47shNgypaahwp4pTVa/qVG/10sUvaYY3k/B88fFEXrRSP3Tg/gnJJAeCt4WeyOgKL57OSHz0KZBCaD1jbzNAMg6yMbpLjApHd28PBVJOOJhAomkdwhCXPhpxmXAOqO1pWJ+8Tl+aOobkNng4JJsO7VQMTpA4oWeUbGp8xu6d+bIeysbxqc8EPhWwVKip6NPX/ITOYsTm2QHsl7s7JsmOPtajBjmUoU32VY3fbemNghSYjSKe5IGvsN0CgYEAzlKahjrTGQdcPaV88Pmf3UcZVhyDdyDBfTbxcZ1IcjMVlqB1sF1DMnkCdf47bsa/PII8ODP7aTt14sQceXJZet/Hrt4pT2bu7r6zCB1u5Jzl00NV/XmmLgYH4vrj3+o/3NK1b/Q5OS2MGgvQxQc6xEJHWl9BPFwoS/9e/qe8lk0CgYEAug3oaIA93QyVhemNFSkx+v9pfamXyOWtaeKGXDSfnNdA/YbMIe5TNe4S6IKfxgAoSXb7Tk1UKk8ZDVPzdBuz9F+K5rO5nmY5Rg8rMi+HzfK7E5Ak6KEnnFfRBsTPYfcNH0GWRVv899jQ2FDJWahLznQeEuMgwnmZ6MEOmc4BztMCgYBNqzzucPCMyH+J2WVqVZ4/r4czKnK3Asaz+13y1jGyg9aJqIgFR2aHdpRdlMIM1pahEanXwoHPQIoFPqw1b72NivZhttI4SNiDWZiN4n6fYw0FdaDGVeggBTcs1CO6ZDV8THnu1jJAewv1tiL2ON1/ii/QLnGhZlPpIA5DsSNGNQKBgQCBkAnWK+fotUiytk8++y8JATAvCBjhF8BJSiwSrbqw990UL/ibcGGV3rJgJAarVZS4hBjBEGyaAfcKJvoUUu5gMOCDg4ixW7JqrUmBa0QBERVhrDFnpkH1R9oSAqAAMpB6wauppUNmPSBCYw+0VdRkcsw2juBTTWb2hOpsBN+RbQKBgH/q3aQ0uFxWQlA9pzaYedvFlEZqkNLvt+2FpFDdC8xdPShJzzhI4KwlnFrHICuhs+zwZQmF/6Xq42egeh53tJvJ0iV4QPYHsJfxdpH980qvOcLCeV1S81d72ZDj1S7QUE+gO0DUOa8VUA+vZRaMqvQ/3BumM59k7yy9LbtBWuhe"
+          "priority": [
+            "100"
           ],
-          "certificate": [
-            "MIIClzCCAX8CBgGK2yCNijANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDARHSVRTMB4XDTIzMDkyODA5MjkxOFoXDTMzMDkyODA5MzA1OFowDzENMAsGA1UEAwwER0lUUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJXzOcZ0gfHYNgIA7HP9E0YiK0QdoavMOAxZ+Z1DpOU+Nbt9kuU6e6A42kuZLanRO/+rJk/ThJC/ifMB/GOO6/vJYzhc8WqQD7wy3Fe12X62HVzmRkW1y4rbj96UN4SiZglTWSwm/zN6akiW+SrB4CzXx5qMmYo4KnQaCqVr6ASoelArYFmniGjSSw5G3boXG3Nxqh6Nh8JfJzMaKhf+LS3akDMK/YuRNQYLi1N5W6TQjOK2hxgow7HnFVHDvW5AZFsc/Kb91QJt/1S9NqYQI5MB2CZkGOweQ2IFetKmxltx8rka9kNsXOSFhcEmOtOIyMcNe7XSI3aVE9+pkY2u13cCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAbkoT31Xgv6qDSkHtDHjHZJVvqzp6ZjOlDoRDOhZLCv4d/AtoQTHtXKCRBBts3/r+GZACeC0EqSPJVDGQztWBe8a7ghEPfHHSy1tCCQZecU9ddZql4V+Pv5c2UW4uilF9baRkHvfD23po2AyRNsJtdybUFuMAriOhG9Dx/P72ICvYZwl3m2bB1EZpt5/VtYZgxExNrbptvYePrV0SAvA/33ORe5mR+TKIMk3mvO27Ce54L50E+WoWxSA3MVs2hbVlDoQa5Gn3soj8Vvj2p14SjS0kpCzQbcuOxxs9U9LXH05Bi1dRPTc3gbD1l6MrAPK1hCqJ3q3N98nvU7i0TTfHGA=="
-          ],
-          "priority": ["100"],
-          "algorithm": ["RSA-OAEP"]
+          "algorithm": [
+            "RSA-OAEP"
+          ]
         }
       },
       {
@@ -1456,12 +1518,12 @@
         "providerId": "hmac-generated",
         "subComponents": {},
         "config": {
-          "kid": ["5344a35d-9d54-4d5a-a62f-c52a7a7eac84"],
-          "secret": [
-            "4Yq_lZjIrT1Pwx9UwrKphRhruoMl1M1QlHXaSbMLQAhQXe7CU-f99GzGL2TCZXS3OMysZch3GX2X4eHE-uhzXA"
+          "priority": [
+            "100"
           ],
-          "priority": ["100"],
-          "algorithm": ["HS256"]
+          "algorithm": [
+            "HS256"
+          ]
         }
       },
       {
@@ -1470,9 +1532,9 @@
         "providerId": "aes-generated",
         "subComponents": {},
         "config": {
-          "kid": ["6de5d466-9602-4878-83f0-7d21a33b0d90"],
-          "secret": ["gEw8hc0_ZSMk2ZZN2TKqlw"],
-          "priority": ["100"]
+          "priority": [
+            "100"
+          ]
         }
       }
     ]
@@ -2119,7 +2181,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "21.1.1",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []


### PR DESCRIPTION
Adds the roles used by GITS:

* `super-user`
* `course-creator`

to the default realm config upon creation of the keycloak container